### PR TITLE
Incrementally write the output file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-pcap-writer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A simple pcap file writer for node.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In case of big files, it is better to incrementally write the file to fs, and not only at the end.
Make that fix in order to let Event Loop process I/O operations.